### PR TITLE
fix: report prompt repetition, wind labeling, and location-timezone timestamps

### DIFF
--- a/bun-service/eval/harness.ts
+++ b/bun-service/eval/harness.ts
@@ -20,7 +20,36 @@ interface MockConditions {
   score: number
 }
 
+// Mirrors isOffshoreWind/getWindDescription in src/app/api/surfability/route.ts so the
+// harness exercises the same ground-truth wind_direction_description the real prompt
+// gets in production (mocked surf data previously omitted it entirely).
+const COAST_FACING_DEG: Record<string, number> = {
+  'st-augustine': 90,
+  'boca-raton': 90,
+  'higgins-beach': 90,
+  'huntington-beach': 225,
+}
+
+function compassOf(degrees: number): string {
+  const directions = ['N', 'NNE', 'NE', 'ENE', 'E', 'ESE', 'SE', 'SSE',
+    'S', 'SSW', 'SW', 'WSW', 'W', 'WNW', 'NW', 'NNW']
+  return directions[Math.round(degrees / 22.5) % 16]!
+}
+
+function windDescriptionOf(windDirection: number, windSpeed: number, coastFacingDeg: number): string {
+  const offshoreCenter = (coastFacingDeg + 180) % 360
+  let diff = Math.abs(windDirection - offshoreCenter)
+  if (diff > 180) diff = 360 - diff
+  const offshore = diff <= 90
+  const windType = offshore ? 'offshore' : 'onshore'
+  const quality = offshore
+    ? (windSpeed < 5 ? 'glassy conditions' : windSpeed < 15 ? 'clean offshore conditions' : windSpeed < 25 ? 'strong offshore - may be difficult to paddle out' : 'very strong offshore - challenging conditions')
+    : (windSpeed < 5 ? 'light onshore - fairly clean' : windSpeed < 10 ? 'moderate onshore - some chop' : windSpeed < 20 ? 'strong onshore - choppy conditions' : 'very strong onshore - blown out')
+  return `${compassOf(windDirection)} ${windType} (${quality})`
+}
+
 function mockSurfData(locationSlug: string, locationName: string, c: MockConditions) {
+  const coastFacingDeg = COAST_FACING_DEG[locationSlug] ?? 90
   return {
     location: locationName,
     locationSlug,
@@ -31,6 +60,7 @@ function mockSurfData(locationSlug: string, locationName: string, c: MockConditi
       swell_direction_deg: c.swell_direction_deg,
       wind_speed_kts: c.wind_speed_kts,
       wind_direction_deg: c.wind_direction_deg,
+      wind_direction_description: windDescriptionOf(c.wind_direction_deg, c.wind_speed_kts, coastFacingDeg),
       tide_state: c.tide_state,
       tide_height_ft: c.tide_height_ft,
     },
@@ -80,6 +110,14 @@ const GOOD_DAY: MockConditions = {
 const LIGHTNING: MockConditions = {
   ...MEDIOCRE,
   weather_description: 'Thunderstorm',
+}
+
+// Repro for the reported bug: NE wind at St. Augustine (east-facing coast) is
+// onshore, but the model previously called it "offshore" when left to derive
+// onshore/offshore itself from local-knowledge phrasing.
+const NE_WIND_BUG_REPRO: MockConditions = {
+  ...MEDIOCRE,
+  wind_direction_deg: 45,
 }
 
 const CROSS_LOCATION_CONTEXTS: Array<{ slug: string; ctx: LocationContext }> = [
@@ -173,6 +211,10 @@ async function main() {
   await runOne('Normal daytime, good conditions', 'st-augustine', ST_AUGUSTINE_CTX.locationName, ST_AUGUSTINE_CTX, GOOD_DAY, DAYTIME_NOW)
   await runOne('Night (before sunrise)', 'st-augustine', ST_AUGUSTINE_CTX.locationName, ST_AUGUSTINE_CTX, MEDIOCRE, NIGHT_NOW)
   await runOne('Lightning / thunderstorm override', 'st-augustine', ST_AUGUSTINE_CTX.locationName, ST_AUGUSTINE_CTX, LIGHTNING, DAYTIME_NOW)
+
+  header('BUG REPRO: NE wind at St. Augustine must be called onshore, not offshore')
+  log('(St. Augustine faces east — coastFacingDeg 90 — so offshore wind blows from the W/NW, not the NE.)')
+  await runOne('St. Augustine — NE wind', 'st-augustine', ST_AUGUSTINE_CTX.locationName, ST_AUGUSTINE_CTX, NE_WIND_BUG_REPRO, DAYTIME_NOW)
 
   const outPath = `eval/output/${new Date().toISOString().replace(/[:.]/g, '-')}.txt`
   await Bun.write(outPath, lines.join('\n') + '\n')

--- a/bun-service/index.ts
+++ b/bun-service/index.ts
@@ -158,6 +158,7 @@ export function createDetailedSurfPrompt(surfData: any, ctx: LocationContext, no
   const windMph = Math.round(surfData.details.wind_speed_kts * 1.15078)
   const swellDirection = getCompassDirection(surfData.details.swell_direction_deg)
   const windDirection = getCompassDirection(surfData.details.wind_direction_deg)
+  const windOnshoreOffshore = surfData.details.wind_direction_description ?? null
   const { hour, formatted: localTime, date: localDate } = getLocalTime(ctx.timezone, now)
   const viability = getSessionViability(hour, ctx.lat, ctx.timezone, surfData.weather.weather_description, now)
 
@@ -208,7 +209,8 @@ CURRENT CONDITIONS (raw data — reference in your own words, see NOTE below on 
 • Wave Height: ${surfData.details.wave_height_ft} feet
 • Wave Period: ${surfData.details.wave_period_sec} seconds
 • Swell Direction: ${surfData.details.swell_direction_deg}° (${swellDirection})
-• Wind: ${windMph} mph ${windDirection}
+• Wind: ${windMph} mph ${windDirection}${windOnshoreOffshore ? `
+• Wind Effect (ground truth, already calculated from this coast's orientation — use this label as-is, do not recompute or contradict it from local knowledge or the compass direction): ${windOnshoreOffshore}` : ''}
 • Tide: ${surfData.details.tide_state} (${surfData.details.tide_height_ft}ft${nextTideStr ? ` — ${nextTideStr}` : ''})
 • Water Temp: ${surfData.weather.water_temperature_f}°F
 • Weather: ${surfData.weather.weather_description}
@@ -229,7 +231,7 @@ THIS CALL'S ANGLE: ${pickOpeningAngle()}
 WRITE 2 PARAGRAPHS, roughly 70-120 words each (vary sentence count and length naturally — do not force a fixed number of sentences):
 
 **Paragraph 1 - Conditions Analysis**:
-Open using THIS CALL'S ANGLE above. Synthesise what the wave height, period, swell direction, and wind actually mean for surf quality at this specific spot — the character of the waves, whether they'll have power or be mushy, onshore/offshore effect. Use your local knowledge of this break to make it specific and accurate. Weave in how the tide and water temp affect the experience.
+Open using THIS CALL'S ANGLE above. Synthesise what the wave height, period, swell direction, and wind actually mean for surf quality at this specific spot — the character of the waves, whether they'll have power or be mushy. For the onshore/offshore effect, use the Wind Effect ground-truth label given above verbatim in meaning (do not re-derive it from the raw wind compass direction or from local-knowledge phrases like "offshore on X winds" — those describe a different location's or spot's typical pattern and can mislead you on today's actual angle). Use your local knowledge of this break to make it specific and accurate otherwise. Weave in how the tide and water temp affect the experience.
 
 **Paragraph 2 - Context & Vibe**:
 Move forward, don't repeat — the reader already has paragraph 1's conditions read, so don't re-explain it in different words. Give the reasoning and local context: why certain spots work or don't in these conditions, what the crowd/vibe will be like, the best window in the day and why, and an honest bottom-line take on whether it's worth paddling out.

--- a/src/app/components/SurfAppClient.tsx
+++ b/src/app/components/SurfAppClient.tsx
@@ -187,7 +187,7 @@ export function SurfAppClient({ initialReport, locationSlug }: Props) {
         </div>
 
         <div className="mt-6 px-4 max-w-3xl w-full">
-          <SurfReportCard report={surfReport} loading={reportLoading} />
+          <SurfReportCard report={surfReport} loading={reportLoading} timezone={location?.timezone} />
           {reportError && <ErrorCard message={reportError} />}
         </div>
 

--- a/src/app/components/surf/SurfReportCard.tsx
+++ b/src/app/components/surf/SurfReportCard.tsx
@@ -29,24 +29,32 @@ interface SurfReport {
 interface SurfReportCardProps {
   report: SurfReport | null;
   loading: boolean;
+  timezone?: string;
 }
 
-export function SurfReportCard({ report, loading }: SurfReportCardProps) {
+export function SurfReportCard({ report, loading, timezone }: SurfReportCardProps) {
   const [formattedTime, setFormattedTime] = useState<string | null>(null);
 
   useEffect(() => {
     if (!report?.timestamp) return;
     const reportTime = new Date(report.timestamp);
     const now = new Date();
+    const dayKeyOpts: Intl.DateTimeFormatOptions = timezone
+      ? { timeZone: timezone, year: 'numeric', month: 'numeric', day: 'numeric' }
+      : { year: 'numeric', month: 'numeric', day: 'numeric' };
     const isToday =
-      reportTime.getFullYear() === now.getFullYear() &&
-      reportTime.getMonth() === now.getMonth() &&
-      reportTime.getDate() === now.getDate();
+      reportTime.toLocaleDateString('en-US', dayKeyOpts) === now.toLocaleDateString('en-US', dayKeyOpts);
     const datePart = isToday
       ? 'Today'
-      : reportTime.toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
-    setFormattedTime(datePart + ' @ ' + reportTime.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }));
-  }, [report?.timestamp]);
+      : reportTime.toLocaleDateString('en-US', { ...dayKeyOpts, month: 'short' });
+    const timePart = reportTime.toLocaleTimeString('en-US', {
+      ...(timezone ? { timeZone: timezone } : {}),
+      hour: '2-digit',
+      minute: '2-digit',
+      timeZoneName: 'short',
+    });
+    setFormattedTime(datePart + ' @ ' + timePart);
+  }, [report?.timestamp, timezone]);
 
   // Don't render anything if loading and no report
   if (loading && !report) {


### PR DESCRIPTION
## Summary
- Rewrote the surf report prompt to eliminate cross-location/cross-day/within-report repetition (rotating opening angles, non-reusable hint lines, loosened structure).
- Fixed wind onshore/offshore mislabeling: the prompt now gets the already-correct, coast-orientation-derived label instead of asking the model to re-derive it from raw compass direction and local-knowledge text (was calling NE wind "offshore" at east-facing St. Augustine).
- Fixed report timestamps to render in the report's location timezone (e.g. HST for Hawaii) instead of the viewer's browser timezone.
- Extended the local eval harness (`bun-service/eval/harness.ts`) to mock the wind ground-truth field and added a repro case for the wind-labeling bug; verified against the live model.

## Test plan
- [x] Ran `bun run eval/harness.ts` against the live model — NE wind at St. Augustine now correctly described as onshore; cross-location/cross-day outputs read as distinct, non-templated writing.
- [ ] Spot-check `swells.surf` after deploy: view a Hawaii report from a non-Hawaii browser and confirm the timestamp shows HST.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_014hzbvQuCeAbEoYhg2dZdiq