### PR TITLE
fix: stop Next.js from caching /api/surf-report's DB query indefinitely

### DIFF
--- a/src/app/api/surf-report/route.ts
+++ b/src/app/api/surf-report/route.ts
@@ -2,6 +2,8 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getCachedReport, saveReport, ensureInitialized } from '@/lib/db';
 import { getLocation, DEFAULT_LOCATION_SLUG, type Location } from '@/lib/locations';
 
+export const dynamic = 'force-dynamic';
+
 export async function GET(request: NextRequest) {
   const startTime = Date.now();
   const isDebug = request.headers.get('X-Debug') === 'true';


### PR DESCRIPTION
## Summary
Discovered while verifying that today's location-knowledge/tide-station fixes (#26, #27) would actually reach users: `/api/surf-report` kept serving the same report indefinitely regardless of DB state or cron runs.

- Confirmed via direct DB query that `surf_reports` had a fresh row for `st-augustine` (correct timestamp, correct new tide data) immediately after triggering `/api/admin/request-forecast`.
- Confirmed via repeated `curl` to `/api/surf-report?location=st-augustine` that the API kept returning an older report — same `id`, same `timestamp`, across multiple requests minutes apart — including a `X-Report-Age-Hours: 0` header that was internally inconsistent with the report's own (stale) timestamp.
- Root cause: `/api/surf-report/route.ts` was missing `export const dynamic = 'force-dynamic'`. Next.js 14 caches `fetch()` calls inside Route Handlers by default; the Neon serverless driver's internal HTTP calls to Neon's Data API weren't opted out, so the query result got frozen in Next's Data Cache (which persists across deployments on Vercel) instead of hitting the DB fresh each request. `/api/surfability/route.ts` and `/api/admin/request-forecast/route.ts` already carry this directive — it was just missing on the one route that actually serves reports to users.

This means the documented 8-hour DB-cache freshness logic in this route has likely been irrelevant in production — it was serving whatever got cached at the Next.js layer, independent of cron regeneration.

## Test plan
- [x] `pnpm type-check` passes
- [ ] After deploy, confirm `/api/surf-report?location=st-augustine` returns the current DB row (matches `SELECT ... ORDER BY timestamp DESC LIMIT 1`) and updates after the next cron run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014hzbvQuCeAbEoYhg2dZdiq