### PR TITLE
fix: correct tide-state calc corrupted by NOAA local-time parsing bug

### DIFF
--- a/src/app/api/surfability/route.ts
+++ b/src/app/api/surfability/route.ts
@@ -261,6 +261,16 @@ async function fetchMarineData(lat: number, lon: number, timezone: string) {
   throw new Error('All marine data sources failed - no real ocean data available');
 }
 
+// NOAA's datagetter returns timestamps as bare "YYYY-MM-DD HH:MM" strings with no
+// UTC offset. Requesting time_zone=gmt makes those strings unambiguous UTC clock
+// values, so they can be parsed into a correct absolute instant with parseNoaaGmtTimestamp
+// below. (The alternative, time_zone=lst_ldt, returns local Eastern time — but `new
+// Date(...)` on a UTC server then silently mis-reads those digits as UTC, shifting
+// every event by the EDT/EST offset and corrupting past/future comparisons.)
+function parseNoaaGmtTimestamp(t: string): Date {
+  return new Date(`${t.replace(' ', 'T')}Z`);
+}
+
 async function fetchTideData(stationId: string): Promise<TideData> {
   try {
     const today = new Date();
@@ -276,8 +286,8 @@ async function fetchTideData(stationId: string): Promise<TideData> {
       return `${year}${month}${day}`;
     };
 
-    const currentUrl = `https://api.tidesandcurrents.noaa.gov/api/prod/datagetter?date=latest&station=${stationId}&product=water_level&datum=MLLW&time_zone=lst_ldt&units=english&application=SurfLab&format=json`;
-    const predictionsUrl = `https://api.tidesandcurrents.noaa.gov/api/prod/datagetter?begin_date=${formatDate(yesterday)}&end_date=${formatDate(tomorrow)}&station=${stationId}&product=predictions&datum=MLLW&time_zone=lst_ldt&interval=hilo&units=english&application=SurfLab&format=json`;
+    const currentUrl = `https://api.tidesandcurrents.noaa.gov/api/prod/datagetter?date=latest&station=${stationId}&product=water_level&datum=MLLW&time_zone=gmt&units=english&application=SurfLab&format=json`;
+    const predictionsUrl = `https://api.tidesandcurrents.noaa.gov/api/prod/datagetter?begin_date=${formatDate(yesterday)}&end_date=${formatDate(tomorrow)}&station=${stationId}&product=predictions&datum=MLLW&time_zone=gmt&interval=hilo&units=english&application=SurfLab&format=json`;
 
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), 8000);
@@ -306,12 +316,15 @@ async function fetchTideData(stationId: string): Promise<TideData> {
       const predictionsData = await predictionsRes.json();
       if (predictionsData.predictions?.length > 0) {
         const now = new Date();
-        const allPredictions = predictionsData.predictions.map((p: any) => ({
-          ...p,
-          time: new Date(p.t),
-          parsedHeight: parseFloat(p.v),
-          timestamp: p.t
-        }));
+        const allPredictions = predictionsData.predictions.map((p: any) => {
+          const time = parseNoaaGmtTimestamp(p.t);
+          return {
+            ...p,
+            time,
+            parsedHeight: parseFloat(p.v),
+            timestamp: time.toISOString()
+          };
+        });
 
         const pastPredictions = allPredictions.filter((p: any) => p.time < now);
         const futurePredictions = allPredictions.filter((p: any) => p.time >= now);
@@ -438,7 +451,7 @@ export async function GET(request: NextRequest) {
       if (!tideEvent) return null;
       const time = new Date(tideEvent.timestamp);
       return {
-        time: time.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true }),
+        time: time.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true, timeZone: location.timezone }),
         height: Math.round(tideEvent.height * 10) / 10,
         timestamp: tideEvent.timestamp
       };


### PR DESCRIPTION
## Summary
- `fetchTideData` requested NOAA predictions with `time_zone=lst_ldt` (bare local Eastern-time strings, no UTC offset). Parsing those with `new Date(p.t)` on a UTC server silently read the digits as UTC, shifting every tide event 4-5 hours early.
- This misclassified still-upcoming tide events as already past, corrupting `previousHigh`/`nextHigh`/`previousLow`/`nextLow` and producing wrong `tide_state` labels — confirmed in production: a report generated at 9:02am EDT said "High Falling" ~1h44m *before* the day's actual high tide, when the tide was still clearly rising.
- Switched NOAA requests to `time_zone=gmt`, added `parseNoaaGmtTimestamp` to correctly parse the now-unambiguous UTC strings, and made `formatTideTime` format display times in the location's own timezone explicitly (previously the bug happened to cancel out for display purposes; that stopped being true once parsing was fixed).

## Test plan
- [x] `pnpm type-check` — clean
- [x] Simulated the exact buggy instant (2026-08-30T13:02:13Z / 9:02am EDT) against real NOAA predictions for station 8720218 — confirmed old logic picks the "Falling" branch, new logic correctly picks "Rising" (104 min to next high vs. 447 min to next low)
- [x] Ran `pnpm dev` and hit `/api/surfability?location=st-augustine` live — tide state, and all four tide-event display times (10:46 AM, 4:12 AM, 4:29 PM, 11:05 PM), match NOAA's published predictions in Eastern time

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014hzbvQuCeAbEoYhg2dZdiq